### PR TITLE
ci: Run package installs through Aikido Safe Chain

### DIFF
--- a/.github/actions/install-safe-chain/action.yml
+++ b/.github/actions/install-safe-chain/action.yml
@@ -1,28 +1,9 @@
-name: Setup
-description: Set up pnpm, Node.js, and Aikido Safe Chain for package-manager hardening
-
-inputs:
-  registry-url:
-    description: Optional registry URL to configure for setup-node (e.g. for npm publishing)
-    required: false
-    default: ""
+name: Install Aikido Safe Chain
+description: Download a pinned install-safe-chain.sh, verify its SHA-256, and run it with --ci so subsequent pnpm/npm commands are screened for malicious packages.
 
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-      with:
-        version: latest
-        run_install: false
-
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-      with:
-        node-version-file: .nvmrc
-        cache: "pnpm"
-        registry-url: ${{ inputs.registry-url }}
-
-    # Install after setup-node, before any package-manager install, per
-    # https://github.com/AikidoSec/safe-chain#usage-in-cicd
     - name: Install Aikido Safe Chain
       shell: bash
       env:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,28 @@
+name: Setup
+description: Set up pnpm, Node.js, and Aikido Safe Chain for package-manager hardening
+
+inputs:
+  registry-url:
+    description: Optional registry URL to configure for setup-node (e.g. for npm publishing)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      with:
+        version: latest
+        run_install: false
+
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version-file: .nvmrc
+        cache: "pnpm"
+        registry-url: ${{ inputs.registry-url }}
+
+    # Install after setup-node, before any package-manager install, per
+    # https://github.com/AikidoSec/safe-chain#usage-in-cicd
+    - name: Install Aikido Safe Chain
+      shell: bash
+      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,4 +25,18 @@ runs:
     # https://github.com/AikidoSec/safe-chain#usage-in-cicd
     - name: Install Aikido Safe Chain
       shell: bash
-      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      env:
+        # Pin both the release tag and the installer's SHA-256 so we don't blindly execute
+        # whatever is served by GitHub. Bump both together by downloading the new installer
+        # and taking its sha256 from the GitHub release asset API.
+        SAFE_CHAIN_VERSION: "1.4.7"
+        SAFE_CHAIN_INSTALLER_SHA256: "54c750232d149106ecf4f5f28fee82ba49d2428f1e411e0ed961c0263ae19eaf"
+      run: |
+        set -euo pipefail
+        installer="$(mktemp)"
+        trap 'rm -f "$installer"' EXIT
+        curl -fsSL \
+          "https://github.com/AikidoSec/safe-chain/releases/download/${SAFE_CHAIN_VERSION}/install-safe-chain.sh" \
+          -o "$installer"
+        echo "${SAFE_CHAIN_INSTALLER_SHA256}  ${installer}" | sha256sum -c -
+        sh "$installer" --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-        with:
-          version: latest
-          run_install: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: .nvmrc
-          cache: "pnpm"
+      - uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: pnpm install
@@ -52,15 +44,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-        with:
-          version: latest
-          run_install: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: .nvmrc
-          cache: "pnpm"
+      - uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: pnpm install
@@ -105,15 +89,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: ./.github/actions/setup
         with:
-          version: latest
-          run_install: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: .nvmrc
-          cache: "pnpm"
           registry-url: 'https://registry.npmjs.org'
 
       # Ensure npm 11.5.1 or later is installed for trusted publishing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+
+      - uses: ./.github/actions/install-safe-chain
 
       - name: Install dependencies
         run: pnpm install
@@ -44,7 +54,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+
+      - uses: ./.github/actions/install-safe-chain
 
       - name: Install dependencies
         run: pnpm install
@@ -89,9 +109,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
           registry-url: 'https://registry.npmjs.org'
+
+      - uses: ./.github/actions/install-safe-chain
 
       # Ensure npm 11.5.1 or later is installed for trusted publishing
       - name: Update npm


### PR DESCRIPTION
Installs the Aikido Safe Chain shim after Node setup so every subsequent pnpm/npm command is screened for known-malicious packages, per https://github.com/AikidoSec/safe-chain#usage-in-cicd. The shared pnpm + Node + Safe Chain setup is extracted into a local composite action so the three jobs don't repeat the step block.